### PR TITLE
add update script; update CLI to v2.15.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,18 @@
+# Hasura DDN CLI packaged for Nix
+
+This repo provides Nix packages for the [Hasura v3 CLI][] via a flake.
+
+[Hasura v3 CLI]: https://hasura.io/docs/3.0/cli/overview/
+
+To run the CLI directly run,
+
+```sh
+$ nix run github:hasura/ddn-cli-nix
+```
+
+You probably want to use the flake in this repository as a flake input in your
+own configuration.
+
 ## Example flake.nix
 
 ```nix
@@ -28,3 +43,23 @@
 0. Install [nix](https://nixos.org/) and ensure [flakes](https://nixos.wiki/wiki/Flakes) are enabled
 1. Run `nix develop`
 2. `ddn` is now available in your shell
+
+## Updating
+
+The packages in this repo package a specific version of the CLI. To update the
+packages to the latest CLI version run the update script:
+
+```
+$ nix run .#update
+```
+
+This requires read access to the CLI source repository to get a list of tags. It
+is also possible to update without repository access by specifying a specific
+version:
+
+```
+$ nix run .#update v2.15.0
+```
+
+Packages can only be set to use versions that have binaries published on
+Hasura's CDN.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ own configuration.
   outputs = { self, nixpkgs, flake-utils, ddnPkg }:
     flake-utils.lib.eachSystem [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ] (system:
       let pkgs = nixpkgs.legacyPackages.${system};
-          ddn = ddnPkg.defaultPackage.${system};
+          ddn = ddnPkg.packages.${system}.default;
           lib =  nixpkgs.lib;
       in {
         devShell = pkgs.mkShell rec {

--- a/flake.nix
+++ b/flake.nix
@@ -7,73 +7,36 @@
   };
 
   outputs = { self, nixpkgs, flake-utils }:
-    flake-utils.lib.eachSystem [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ] (system:
-      let pkgs = nixpkgs.legacyPackages.${system};
-          lib =  nixpkgs.lib;
+    flake-utils.lib.eachSystem [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ]
+      (system:
+        let
+          pkgs = import nixpkgs {
+            inherit system;
+            config.allowUnfree = true;
+          };
 
-          # If you change this version you will have to update all of the hashes below.
-          # You can get each hash by running:
-          #
-          #     $ nix store prefetch-file <url>
-          #
-          # Make sure to preserve the "sha256-" prefix when pasting here.
-          ver = "v2.0.1";
-          url = arch: "https://graphql-engine-cdn.hasura.io/ddn/cli/v4/${ver}/cli-ddn-${arch}";
+          binary-url-pattern = "https://graphql-engine-cdn.hasura.io/ddn/cli/v4/VERSION/cli-ddn-PLATFORM-ARCH";
+        in
+        {
+          packages = rec {
+            ddn = pkgs.callPackage ./packages/ddn.nix { inherit binary-url-pattern; };
+            default = ddn;
 
-          sysSpec = 
-              if system == "x86_64-linux" then rec
-                { 
-                  arch = "linux-amd64";
-                  src = pkgs.fetchurl {
-                    url = url arch;
-                    sha256 = "sha256-wnkF5F8X697KgH/ALaRGKSEth0ldN094HvkydOPBc9E=";
-                  };
-                }
-              else if system == "x86_64-darwin" then rec
-                { 
-                  arch = "darwin-amd64";
-                  src = pkgs.fetchurl {
-                    url = url arch;
-                    sha256 = "sha256-1/QyYdqBDFvbuHyDbQ5pq6YEr0CouNc2J41xnu9/XVA=";
-                  };
-                }
-              else if system == "aarch64-darwin" then rec
-                { 
-                  arch = "darwin-arm64";
-                  src = pkgs.fetchurl {
-                    url = url arch;
-                    sha256 = "sha256-sw7X+vO9oYnDObvv0Ol5Eo2Fz9rLwax9iOnRWCz4Td4=";
-                  };
-                }
-              else builtins.throw "Unsupported system";
-      in
-        { 
-          packages.default = pkgs.stdenv.mkDerivation rec {
-            name = "ddn";
-
-            version = ver;
-
-            arch = sysSpec.arch;
-
-            # https://nixos.wiki/wiki/Packaging/Binaries
-            src = sysSpec.src;
-
-            sourceRoot = ".";
-
-            dontUnpack = true;
-
-            installPhase = ''
-            runHook preInstall
-            install -m755 -D ${src} $out/bin/ddn
-            runHook postInstall
-            '';
-
-            meta = with lib; {
-              homepage = "https://hasura.io/ddn";
-              description = "Hasura DDN";
-              platforms = platforms.all;
+            update = pkgs.writeShellApplication {
+              name = "update";
+              runtimeInputs = with pkgs; [
+                common-updater-scripts # provides list-git-tags
+                coreutils
+                gnugrep
+                jq
+              ];
+              text = ''
+                BINARY_URL_PATTERN='${binary-url-pattern}'
+                ${builtins.readFile ./scripts/update.sh}
+              '';
             };
           };
+
         }) // {
 
       overlays.default = final: prev: {

--- a/packages/ddn.nix
+++ b/packages/ddn.nix
@@ -1,0 +1,51 @@
+{ hostPlatform
+, fetchurl
+, stdenvNoCC
+, lib
+, binary-url-pattern
+}:
+let
+  version = "v2.15.0";
+  src-url = version: system: builtins.replaceStrings
+    [ "VERSION" "PLATFORM-ARCH" ]
+    [ version (go-system system) ]
+    binary-url-pattern
+  ;
+  go-system = system: {
+    "x86_64-linux" = "linux-amd64";
+    "x86_64-darwin" = "darwin-amd64";
+    "aarch64-darwin" = "darwin-arm64";
+  }.${system};
+  hash = system: {
+    "linux-amd64" = "sha256-05HpsrMKgP5t2Pn8yJCMq2HvkEAG5R2tomUerAymCj8=";
+    "darwin-amd64" = "sha256-KHH/Zg8kh7gmiNoP9FKH3ytkUHY/WzG+EUMM3dxTWW4=";
+    "darwin-arm64" = "sha256-72wMb2gp+55b0dAy9o4x4HpiP70PVTaH1RCULcLAoR0=";
+  }.${system};
+  src = system: fetchurl {
+    url = src-url version system;
+    hash = hash (go-system system);
+  };
+in
+stdenvNoCC.mkDerivation {
+  name = "ddn";
+  inherit version;
+  src = src hostPlatform.system;
+  phases = [ "installPhase" "patchPhase" ];
+  installPhase = ''
+    mkdir -p "$out/bin"
+    cp $src "$out/bin/ddn"
+    chmod +x "$out/bin/ddn"
+  '';
+
+  meta = {
+    description = "CLI for managing Hasura DDN data graphs";
+    homepage = "https://hasura.io/docs/3.0/cli/overview/";
+    license = lib.licenses.unfreeRedistributable;
+    mainProgram = "ddn";
+    platforms = [
+      "x86_64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ];
+  };
+}

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -18,6 +18,7 @@ else
 fi
 
 REPO_URL="${REPO_URL:="git@github.com:hasura/v3-cli-go.git"}";
+PACKAGE_EXPRESSION="${PACKAGE_EXPRESSION:="packages/ddn.nix"}";
 
 function list-tags() {
   list-git-tags --url="$REPO_URL" \
@@ -38,7 +39,7 @@ function fetch-hash() {
 function main() {
   local version="${VERSION:=$(latest-tag)}"
 
-  sed -i "s|version\s*=[^;]*;|version = \"$version\";|" packages/ddn.nix
+  sed -i "s|version\s*=[^;]*;|version = \"$version\";|" "$PACKAGE_EXPRESSION"
 
   for system in "darwin-amd64" "darwin-arm64" "linux-amd64"; do
     local urlWithVersion="${BINARY_URL_PATTERN//VERSION/$version}"
@@ -46,7 +47,7 @@ function main() {
     local hash
     hash=$(fetch-hash "$url")
 
-    sed -i "s|\"$system\"\s*=[^;]*;|\"$system\" = \"$hash\";|" packages/ddn.nix
+    sed -i "s|\"$system\"\s*=[^;]*;|\"$system\" = \"$hash\";|" "$PACKAGE_EXPRESSION"
   done
 
   # Echo success message to stderr to provide feedback. Echo version to stdout

--- a/scripts/update.sh
+++ b/scripts/update.sh
@@ -1,0 +1,58 @@
+# Automatically updates ddn.nix to build the given version of the CLI. Run with
+# an argument to specify a specific version, e.g. v2.15.0. Or run without
+# arguments to automatically select the latest version (requires read access to
+# the CLI repo).
+#
+# Run this script through its nix package:
+#
+#     $ nix run .#update
+#
+# Assumes that these environment variables are set:
+#
+# - BINARY_URL_PATTERN
+
+if [ $# -eq 0 ]; then
+  VERSION=""
+else
+  VERSION="$1"
+fi
+
+REPO_URL="${REPO_URL:="git@github.com:hasura/v3-cli-go.git"}";
+
+function list-tags() {
+  list-git-tags --url="$REPO_URL" \
+    | grep -E "^v[0-9.]+$" # excludes pre-releases
+}
+
+function latest-tag() {
+  list-tags \
+    | sort --version-sort --reverse \
+    | head --lines=1
+}
+
+function fetch-hash() {
+  local url="$1"
+  nix store prefetch-file --json "$url" | jq -r .hash
+}
+
+function main() {
+  local version="${VERSION:=$(latest-tag)}"
+
+  sed -i "s|version\s*=[^;]*;|version = \"$version\";|" packages/ddn.nix
+
+  for system in "darwin-amd64" "darwin-arm64" "linux-amd64"; do
+    local urlWithVersion="${BINARY_URL_PATTERN//VERSION/$version}"
+    local url="${urlWithVersion//PLATFORM-ARCH/$system}"
+    local hash
+    hash=$(fetch-hash "$url")
+
+    sed -i "s|\"$system\"\s*=[^;]*;|\"$system\" = \"$hash\";|" packages/ddn.nix
+  done
+
+  # Echo success message to stderr to provide feedback. Echo version to stdout
+  # so that another script can easily read the version string.
+  >&2 echo "Updated successfully"
+  echo "$version"
+}
+
+main


### PR DESCRIPTION
As described in the readme you can automatically update the version and hashes for the latest CLI release by running,

```sh
$ nix run .#update
```

Updates to CLI version 2.15.0.

I'm thinking of following up on this with CI automation on a schedule to automatically check for CLI releases, commit the update, and tag this repo.