### PR TITLE
wrap with FHS for subcommands that run embedded executable

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,34 +1,16 @@
 {
   "nodes": {
-    "flake-utils": {
-      "inputs": {
-        "systems": "systems"
-      },
-      "locked": {
-        "lastModified": 1710146030,
-        "narHash": "sha256-SZ5L6eA7HJ/nmkzGG7/ISclqe6oZdOZTNoesiInkXPQ=",
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "rev": "b1d9ab70662946ef0850d488da1c9019f3a9752a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "numtide",
-        "repo": "flake-utils",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1723362943,
-        "narHash": "sha256-dFZRVSgmJkyM0bkPpaYRtG/kRMRTorUIDj8BxoOt1T4=",
-        "owner": "nixos",
+        "lastModified": 1746461020,
+        "narHash": "sha256-7+pG1I9jvxNlmln4YgnlW4o+w0TZX24k688mibiFDUE=",
+        "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "a58bc8ad779655e790115244571758e8de055e3d",
+        "rev": "3730d8a308f94996a9ba7c7138ede69c1b9ac4ae",
         "type": "github"
       },
       "original": {
-        "owner": "nixos",
+        "owner": "NixOS",
         "ref": "nixos-unstable",
         "repo": "nixpkgs",
         "type": "github"
@@ -36,23 +18,7 @@
     },
     "root": {
       "inputs": {
-        "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
-      }
-    },
-    "systems": {
-      "locked": {
-        "lastModified": 1681028828,
-        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
-        "owner": "nix-systems",
-        "repo": "default",
-        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-systems",
-        "repo": "default",
-        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -2,47 +2,48 @@
   description = "Hasura DDN CLI";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
-    flake-utils.url = "github:numtide/flake-utils";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
   };
 
-  outputs = { self, nixpkgs, flake-utils }:
-    flake-utils.lib.eachSystem [ "x86_64-linux" "x86_64-darwin" "aarch64-darwin" ]
-      (system:
-        let
-          pkgs = import nixpkgs {
-            inherit system;
-            config.allowUnfree = true;
-          };
+  outputs = { self, nixpkgs }:
+    let
+      systems = [
+        "x86_64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+      mkPkgs = system: import nixpkgs {
+        inherit system;
+        config.allowUnfree = true;
+      };
+      eachSystem = callback: nixpkgs.lib.genAttrs systems (system: callback (mkPkgs system));
+      binary-url-pattern = "https://graphql-engine-cdn.hasura.io/ddn/cli/v4/VERSION/cli-ddn-PLATFORM-ARCH";
+    in
+    {
+      packages = eachSystem (pkgs: rec {
+        default = ddn;
+        ddn = pkgs.callPackage ./packages/ddn.nix { inherit binary-url-pattern; };
 
-          binary-url-pattern = "https://graphql-engine-cdn.hasura.io/ddn/cli/v4/VERSION/cli-ddn-PLATFORM-ARCH";
-        in
-        {
-          packages = rec {
-            ddn = pkgs.callPackage ./packages/ddn.nix { inherit binary-url-pattern; };
-            default = ddn;
+        update = pkgs.writeShellApplication {
+          name = "update";
+          runtimeInputs = with pkgs; [
+            coreutils
+            curl
+            gnugrep
+            jq
+          ];
+          text = ''
+            BINARY_URL_PATTERN='${binary-url-pattern}'
+            ${builtins.readFile ./scripts/update.sh}
+          '';
+        };
+      });
 
-            update = pkgs.writeShellApplication {
-              name = "update";
-              runtimeInputs = with pkgs; [
-                coreutils
-                curl
-                gnugrep
-                jq
-              ];
-              text = ''
-                BINARY_URL_PATTERN='${binary-url-pattern}'
-                ${builtins.readFile ./scripts/update.sh}
-              '';
-            };
-          };
-
-          checks = {
-            default = pkgs.callPackage ./packages/check.nix {
-              ddn = self.packages.${system}.ddn;
-            };
-          };
-        }) // {
+      checks = eachSystem (pkgs: {
+        default = pkgs.callPackage ./packages/check.nix {
+          ddn = self.packages.${pkgs.system}.ddn;
+        };
+      });
 
       overlays.default = final: prev: {
         ddn = self.packages.${final.system}.default;

--- a/packages/ddn.nix
+++ b/packages/ddn.nix
@@ -1,8 +1,6 @@
-{ hostPlatform
+{ binary-url-pattern
+, buildFHSEnv
 , fetchurl
-, stdenvNoCC
-, lib
-, binary-url-pattern
 }:
 let
   version = "v2.29.0";
@@ -25,27 +23,39 @@ let
     url = src-url version system;
     hash = hash (go-system system);
   };
-in
-stdenvNoCC.mkDerivation {
-  name = "ddn";
-  inherit version;
-  src = src hostPlatform.system;
-  phases = [ "installPhase" "patchPhase" ];
-  installPhase = ''
-    mkdir -p "$out/bin"
-    cp $src "$out/bin/ddn"
-    chmod +x "$out/bin/ddn"
-  '';
 
-  meta = {
-    description = "CLI for managing Hasura DDN data graphs";
-    homepage = "https://hasura.io/docs/3.0/cli/overview/";
-    license = lib.licenses.unfreeRedistributable;
-    mainProgram = "ddn";
-    platforms = [
-      "x86_64-linux"
-      "x86_64-darwin"
-      "aarch64-darwin"
-    ];
+  # This function defines a package containing the DDN CLI binary, and nothing
+  # else.
+  ddn-unwrapped = { lib, hostPlatform, stdenvNoCC }: stdenvNoCC.mkDerivation {
+    name = "ddn-unwrapped";
+    inherit version;
+    src = src hostPlatform.system;
+    phases = [ "installPhase" "patchPhase" ];
+    installPhase = ''
+      mkdir -p "$out/bin"
+      cp "$src" "$out/bin/ddn"
+      chmod +x "$out/bin/ddn"
+    '';
+
+    meta = {
+      description = "CLI for managing Hasura DDN data graphs";
+      homepage = "https://hasura.io/docs/3.0/cli/overview/";
+      license = lib.licenses.unfreeRedistributable;
+      mainProgram = "ddn";
+      platforms = [
+        "x86_64-linux"
+        "x86_64-darwin"
+        "aarch64-darwin"
+      ];
+    };
   };
+in
+# The CLI binary is statically-linked, but it contains an embedded executable
+  # that is dynamically-linked, and requires /lib64/ld-linux-x86-64.so.2. So we
+  # need to build an FHS wrapper to provide the necessary interpreter at the
+  # expected path.
+buildFHSEnv {
+  name = "ddn";
+  targetPkgs = pkgs: [ (pkgs.callPackage ddn-unwrapped { }) ];
+  runScript = "ddn";
 }


### PR DESCRIPTION
The package in this repo provides a precompiled, statically-linked binary. However although the main binary is statically-linked, it includes an embedded binary that is required for some subcommands that is **dynamically** linked. This means that those subcommands don't work on NixOS if the user is not using nix-ld.

The embedded binary does not have any runtime dependencies - it only needs its interpreter, `ld`. Ideally we would patch the binary to replace references of the form `/lib64/ld-linux-x86-64.so.2` with corresponding nix store paths. But I don't know how to do that. So instead this change wraps the binary with an FHS which makes the interpreter available at the expected path in a fake filesystem.

I also refactored `flake.nix` to remove the use of flake-utils just because I prefer it this way.

Fixes https://github.com/hasura/graphql-engine/issues/10725